### PR TITLE
Repin to boost 1.67

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,4 +5,4 @@ IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 
 export CFLAGS="-I$PREFIX/include"
 
-exec python setup.py install --single-version-externally-managed --record record.txt
+exec python -m pip install --no-deps --ignore-installed .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - boost-python.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
@@ -22,7 +22,7 @@ requirements:
   build:
     - toolchain
     - gcc  # [osx]
-    - boost 1.66.0
+    - boost 1.67.0
     - casacore 2.4.*
     - numpy 1.8.*  # [py27]
     - numpy 1.9.*  # [py35]
@@ -30,7 +30,7 @@ requirements:
     - python
     - setuptools
   run:
-    - boost 1.66.0
+    - boost 1.67.0
     - casacore 2.4.*
     - numpy >=1.8  # [py27]
     - numpy >=1.9  # [py35]


### PR DESCRIPTION
Not going to switch to conda-build 3 or fancy pinning since we need to be compatible with casacore's C++ build and I worry strongly about breaking that. But, I did also try switching to the new, recommended pip-based installation command.